### PR TITLE
using the same style `discoverServices()`

### DIFF
--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -121,23 +121,25 @@ class BluetoothDevice {
         .map((p) => p.mtu);
   }
 
-  /// Request to change the MTU Size
+  /// Request to change the MTU Size and returns the response back
   /// Throws error if request did not complete successfully
-  Future<void> requestMtu(int desiredMtu) async {
+  Future<int> requestMtu(int desiredMtu) async {
     var request = protos.MtuSizeRequest.create()
       ..remoteId = id.toString()
       ..mtu = desiredMtu;
 
-    await FlutterBlue.instance._channel
-        .invokeMethod('requestMtu', request.writeToBuffer());
-    
-    await FlutterBlue.instance._methodStream
+    var response = FlutterBlue.instance._methodStream
         .where((m) => m.method == "MtuSize")
         .map((m) => m.arguments)
         .map((buffer) => protos.MtuSizeResponse.fromBuffer(buffer))
         .where((p) => p.remoteId == id.toString())
         .map((p) => p.mtu)
         .first;
+
+    await FlutterBlue.instance._channel
+        .invokeMethod('requestMtu', request.writeToBuffer());
+
+    return response;
   }
 
   /// Indicates whether the Bluetooth Device can send a write without response


### PR DESCRIPTION
* to ensure that we don't miss the call from the response we should have
  the listener setup before calling the `requestMtu` internal function
* instead of using the stream just for locking, we can also return the
  value
* awaiting the final call doesn't make any difference so its clearer to
  return it as the caller needs to `await` anyways